### PR TITLE
Export settings background

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # 0.2.x
 
+## 0.2.1
+
+- I replaced the default qwerty bindings for note input with a more "standard" layout. This information is stored in config.ini, so if you want the update, make sure to delete Documents/cacophony/config.ini if it exists (Cacophony will use the default data/config.ini instead).
+- The background of the export settings panel was the same color as the text, so that it just looked like a weird gray rectangle. I fixed it.
+
 ## 0.2.0
 
 Cacophony uses a lot of CPU resources even when it's idle. It shouldn't do that! I reduced Cacophony's CPU usage by around 50%; the exact percentage varies depending on the CPU and the OS. This update is the first big CPU optimization, and probably the most significant.
@@ -11,10 +16,6 @@ These are the optimizations:
 - A tiny optimization to drawing panel backgrounds. This required refactoring throughout `render`. I think that there are more tiny optimizations that could be made in `render` that cumulatively might make more of a difference.
 
 This update doesn't have any new features or bug fixes. In the future, I'm going to reserve major releases (0.x.0) for big new features, but I had to rewrite so much of Cacophony's code, and the results are such a big improvement, that I'm making this a major release anyway.
-
-## 0.2.1
-
-I replaced the default qwerty bindings for note input with a more "standard" layout. This information is stored in config.ini, so if you want the update, make sure to delete Documents/cacophony/config.ini if it exists (Cacophony will use the default data/config.ini instead).
 
 # 0.1.x
 

--- a/render/src/export_settings_panel.rs
+++ b/render/src/export_settings_panel.rs
@@ -372,7 +372,7 @@ impl Drawable for ExportSettingsPanel {
         renderer.rectangle_pixel(
             background.background.position,
             background.background.size,
-            &color,
+            &ColorKey::Background,
         );
         renderer.rectangle_lines(&background.border, &color);
         renderer.rectangle(&self.title_rect, &ColorKey::Background);


### PR DESCRIPTION
The background of the export settings panel was the same color as the text, so that it just looked like a weird gray rectangle. I fixed it.