### PR TITLE
Fixed: Can't play music when a new save file loads

### DIFF
--- a/audio/src/conn.rs
+++ b/audio/src/conn.rs
@@ -248,8 +248,10 @@ impl Conn {
         synth.set_sample_rate(self.framerate);
         drop(synth);
 
-        // Enqueue note events.
         let mut midi_event_queue = self.midi_event_queue.lock();
+        // Clear the queue before adding new events.
+        midi_event_queue.clear();
+        // Enqueue note events.
         for track in state.music.get_playable_tracks().iter() {
             for note in track.get_playback_notes(state.time.playback) {
                 // Note-on event.

--- a/audio/src/midi_event_queue.rs
+++ b/audio/src/midi_event_queue.rs
@@ -39,4 +39,9 @@ impl MidiEventQueue {
         }
         midi_events
     }
+
+    /// Clear the queue.
+    pub(crate) fn clear(&mut self) {
+        self.events.clear()
+    }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@
 - Fixed: There was an input bug where the play/start key (spacebar) was sometimes unresponsive for the first few presses. This is because audio was still decaying from a previous play, meaning that technically the previous play was still ongoing.
 - Fixed: When a new file is created or when a new save file loaded, the app didn't reset correctly.
 - Fixed: If you try to play music and there are no tracks or no playable notes, the app starts playing music and then immediately stops.
+- Fixed: If you're playing music and then load a save file, the save file can't play music because the synthesizer still has MIDI events from the previous music.
 
 ## 0.2.1
 


### PR DESCRIPTION
Fixed: If you're playing music and then load a save file, the save file can't play music because the synthesizer still has MIDI events from the previous music.