### PR TITLE
Macos14

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,12 +54,12 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: macos-11
-            version: 11
           - os: macos-12
             version: 12
           - os: macos-13
             version: 13
+          - os: macos-14
+            version: 14
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-22.04, ubuntu-20.04, macOS-13, macOS-12, macOS-11, windows-latest]
+        os: [ubuntu-22.04, ubuntu-20.04, macOS-14, macOS-13, macOS-12, windows-latest]
     steps:
       # Checkout the branch being tested
       - uses: actions/checkout@v4

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.2.5
 
+- Dropped MacOS 11 builds on itch because there isn't a GitHub workflow runner anymore.
+- Added MacOS 14 builds to itch.
 - Fixed: Crash if a Channel Pressure or Program Change message is sent from a MIDI controller.
 - (Backend) Added some more tests
 - (Backend) Bumped ureq version (fixes a security warning)


### PR DESCRIPTION
- Dropped MacOS 11 builds on itch because there isn't a GitHub workflow runner anymore.
- Added MacOS 14 builds to itch.