### PR TITLE
build data dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Windows:
 
 1. `cargo build --release`
 
+## Set the `data` directory
+
+Cacophony's default data directory is located at `../data`. To set the default data directory at *compile time*, set the `CACOPHONY_BUILD_DATA_DIR` enviroment variable:
+
+```bash
+export CACOPHONY_BUILD_DATA_DIR=/usr/share/cacophony
+cargo build --release
+```
+
 ## Tests
 
 To test, just `cargo test --all`.

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ## 0.2.6
 
 - Fixed: If you let all notes in your music play (as opposed to stopping in the middle), it frequently becomes impossible to play or add new notes.
+- Added a build env variable: Set `CACOPHONY_BUILD_DATA_DIR` to set the default path to the data directory.
 
 ## 0.2.5
 

--- a/common/src/lib.rs
+++ b/common/src/lib.rs
@@ -46,6 +46,7 @@ pub use piano_roll_mode::PianoRollMode;
 use std::env::current_dir;
 use std::fs::{metadata, File};
 use std::io::Read;
+use std::option_env;
 use std::path::{Path, PathBuf};
 pub mod font;
 pub mod open_file;
@@ -72,7 +73,10 @@ pub fn get_bytes(path: &Path) -> Vec<u8> {
 
 /// Default directory for looking at the 'data/' folder.
 pub fn get_default_data_folder() -> PathBuf {
-    current_dir().unwrap().join("data")
+    match option_env!("CACOPHONY_BUILD_DATA_DIR") {
+        Some(dir) => PathBuf::from(dir),
+        None => current_dir().unwrap().join("data"),
+    }
 }
 
 #[cfg(debug_assertions)]


### PR DESCRIPTION
Closes #51 

Set `CACOPHONY_BUILD_DATA_DIR` to set the compile-time default data directory.