### PR TITLE
Fixed: Note-off events don't always happen at the end of a track

### DIFF
--- a/audio/src/conn.rs
+++ b/audio/src/conn.rs
@@ -455,15 +455,18 @@ impl Conn {
             // Set the initial wav export state.
             Self::set_export_state_wav(exportable, &export_state, 0);
             let mut synth = synth.lock();
-            for t in 0..total_samples {
+            for t in 0..=total_samples {
                 // Get and send each event at this time.
                 for event in exportable.events.dequeue(t).iter() {
                     let _ = synth.send_event(*event);
                 }
                 // Set the export state.
                 Self::set_export_state_wav(exportable, &export_state, t);
-                let t = t as usize;
-                (left[t], right[t]) = synth.read_next();
+                // We are iterating to `total_samples` in order to get events at t=1.
+                if t < total_samples {
+                    let t = t as usize;
+                    (left[t], right[t]) = synth.read_next();
+                }
             }
             // Append decaying silence.
             Self::set_export_state(&export_state, ExportState::AppendingDecay);

--- a/audio/src/decayer.rs
+++ b/audio/src/decayer.rs
@@ -26,7 +26,7 @@ impl Default for Decayer {
 
 impl Decayer {
     pub fn decay_shared(&mut self, synth: &SharedSynth, len: usize) {
-        for sample in self.buffer[0..len].chunks_mut(2) {
+        for sample in self.buffer[0..Self::get_len(len)].chunks_mut(2) {
             let mut synth = synth.lock();
             synth.write(sample);
         }
@@ -48,6 +48,15 @@ impl Decayer {
     }
 
     fn set_decaying(&mut self, len: usize) {
-        self.decaying = self.buffer[0..len].iter().any(|s| s.abs() > SILENCE);
+        self.decaying = self.buffer[0..Self::get_len(len)].iter().any(|s| s.abs() > SILENCE);
+    }
+
+    fn get_len(len: usize) -> usize {
+        if len <= DECAY_CHUNK_SIZE {
+            len
+        }
+        else {
+            DECAY_CHUNK_SIZE
+        }
     }
 }

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 ## 0.2.7
 
+- Fixed: Note-off events at the end of a track are sometimes not detected during export
+- Fixed: Panic when decaying audio if the output buffer exceeds the length of the decay buffer.
 - Allow alphanumeric input in `--events events.txt`.
 
 ## 0.2.6


### PR DESCRIPTION
- Fixed: Note-off events at the end of a track are sometimes not detected during export
- Fixed: Panic when decaying audio if the output buffer exceeds the length of the decay buffer.